### PR TITLE
Change to TARGET_OS_SIMULATOR

### DIFF
--- a/ios/RNIsDeviceRooted.m
+++ b/ios/RNIsDeviceRooted.m
@@ -57,7 +57,7 @@ RCT_REMAP_METHOD(isDeviceRooted,
 
 BOOL isJailbroken()
 {
-#if !(TARGET_IPHONE_SIMULATOR)
+#if !(TARGET_OS_SIMULATOR)
     
     if ([[NSFileManager defaultManager] fileExistsAtPath:@"/Applications/Cydia.app"] ||
         [[NSFileManager defaultManager] fileExistsAtPath:@"/Library/MobileSubstrate/MobileSubstrate.dylib"] ||


### PR DESCRIPTION
According to https://stackoverflow.com/questions/35096307/ios-handling-target-iphone-simulator-macro, TARGET_IPHONE_SIMULATOR is now deprecated. This PR changes it to TARGET_OS_SIMULATOR